### PR TITLE
Use correct values for traffic down and up

### DIFF
--- a/fritzbox__traffic_down.py
+++ b/fritzbox__traffic_down.py
@@ -57,7 +57,7 @@ def print_config():
     max_traffic = conn.max_bit_rate
 
     print("host_name %s" % hostname)
-    print("graph_title AVM Fritz!Box WAN traffic")
+    print("graph_title AVM Fritz!Box WAN traffic (received)")
     print("graph_args --base 1000")
     print("graph_vlabel bit down per ${graph_period}")
     print("graph_category network")
@@ -65,16 +65,15 @@ def print_config():
     print("down.label bps")
     print("down.type GAUGE")
     print("down.draw AREA")
-    print("down.graph no")
     print("down.min 0")
     print("down.max %d" % max_traffic[1])
     print("down.warning %.0f" % (max_traffic[1]*0.6))
     print("down.critical %.0f" % (max_traffic[1]*0.8))
     print("down.info Traffic of the WAN interface.")
     if not os.environ.get('traffic_remove_max') or "false" in os.environ.get('traffic_remove_max'):
-        print("maxdown.label received")
+        print("maxdown.label MAX")
         print("maxdown.type GAUGE")
-        print("maxdown.graph no")
+        print("maxdown.graph LINE1")
         print("maxdown.info Maximum down speed of the WAN interface.")
     if os.environ.get('host_name'):
         print("host_name " + os.environ['host_name'])

--- a/fritzbox__traffic_up.py
+++ b/fritzbox__traffic_up.py
@@ -57,7 +57,7 @@ def print_config():
     max_traffic = conn.max_bit_rate
 
     print("host_name %s" % hostname)
-    print("graph_title AVM Fritz!Box WAN traffic")
+    print("graph_title AVM Fritz!Box WAN traffic (send)")
     print("graph_args --base 1000")
     print("graph_vlabel bit up per ${graph_period}")
     print("graph_category network")
@@ -66,9 +66,9 @@ def print_config():
     print("up.type GAUGE")
     print("up.draw AREA")
     print("up.min 0")
-    print("up.max %d" % max_traffic[1])
-    print("up.warning %.0f" % (max_traffic[1]*0.6))
-    print("up.critical %.0f" % (max_traffic[1]*0.8))
+    print("up.max %d" % max_traffic[0])
+    print("up.warning %.0f" % (max_traffic[0]*0.6))
+    print("up.critical %.0f" % (max_traffic[0]*0.8))
     print("up.info Traffic of the WAN interface.")
     if not os.environ.get('traffic_remove_max') or "false" in os.environ.get('traffic_remove_max'):
         print("maxup.label MAX")


### PR DESCRIPTION
Enhance the labels of traffic down and traffic up to differentiate them.
Fix traffic_down to show the graph and data like traffic_up.
Use correct max_traffic value for traffic_up.